### PR TITLE
Initialize query buffer

### DIFF
--- a/C/tpch/sf1.c
+++ b/C/tpch/sf1.c
@@ -150,7 +150,7 @@ int main(int argc, char **argv)
     monetdbe_column* rcols[1];
     monetdbe_column_int64_t* col;
     int64_t* r;
-    char* q;
+    char q[4096] = { 0 };
     clock_t start, end;
 
     // second argument is a string for the db directory or NULL for in-memory mode


### PR DESCRIPTION
I was attempting to run the tpch sf1 program, but I kept getting a segfault. I believe it's because the query buffer is never initialized before it is written to by sprintf.

After making this change, I appear to be able to run the program successfully.